### PR TITLE
Fix unmarshal of fields.

### DIFF
--- a/fields.go
+++ b/fields.go
@@ -25,6 +25,7 @@ const (
 	FieldTypeAlias     FieldType = "alias"
 	FieldTypeDate      FieldType = "date"
 	FieldTypeTimestamp FieldType = "timestamp"
+	FieldTypeUUID      FieldType = "uuid"
 )
 
 type FieldMeta struct {
@@ -306,11 +307,13 @@ func (cr *clientFields) Create(ctx context.Context, field *Field) (*Field, error
 	if err != nil {
 		return nil, fmt.Errorf("directus: cannot prepare request: %v", err)
 	}
-	var reply Field
+	var reply = struct {
+		Data *Field `json:"data"`
+	}{}
 	if err := cr.client.sendRequest(req, &reply); err != nil {
 		return nil, err
 	}
-	return &reply, nil
+	return reply.Data, nil
 }
 
 func (cr *clientFields) Delete(ctx context.Context, collection, field string) error {
@@ -337,9 +340,11 @@ func (cr *clientFields) Patch(ctx context.Context, f *Field) (*Field, error) {
 	if err != nil {
 		return nil, fmt.Errorf("directus: cannot prepare request: %v", err)
 	}
-	var reply Field
+	var reply = struct {
+		Data *Field `json:"data"`
+	}{}
 	if err := cr.client.sendRequest(req, &reply); err != nil {
 		return nil, err
 	}
-	return &reply, nil
+	return reply.Data, nil
 }

--- a/fields.go
+++ b/fields.go
@@ -284,11 +284,13 @@ func (cr *clientFields) Get(ctx context.Context, collection, field string) (*Fie
 	if err != nil {
 		return nil, fmt.Errorf("directus: cannot prepare request: %v", err)
 	}
-	var reply Field
+	var reply = struct {
+		Data *Field `json:"data"`
+	}{}
 	if err := cr.client.sendRequest(req, &reply); err != nil {
 		return nil, err
 	}
-	return &reply, nil
+	return reply.Data, nil
 }
 
 func (cr *clientFields) Create(ctx context.Context, field *Field) (*Field, error) {

--- a/fields_test.go
+++ b/fields_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestFieldMetaUnmarshal(t *testing.T) {
 	data := []byte(`
-		{
+		{ "data" : {
 			"collection": "contact_data",
 			"field": "phone",
 			"type": "string",
@@ -60,17 +60,20 @@ func TestFieldMetaUnmarshal(t *testing.T) {
 				"validation": null,
 				"validation_message": null
 			}
-		}
+	}}
 	`)
-	var field Field
-	require.NoError(t, json.Unmarshal(data, &field))
+	var reply = struct {
+		Data *Field `json:"data"`
+	}{}
+	require.NoError(t, json.Unmarshal(data, &reply))
+	field := reply.Data
 	require.EqualValues(t, field.Meta.ID, 1406)
 	require.Equal(t, field.Meta.Width, FieldWidthHalf)
 }
 
 func TestFieldMetaOptionsChoicesString(t *testing.T) {
 	data := []byte(`
-		{
+		{ "data":{
 			"collection": "contact_data",
 			"field": "phone",
 			"type": "string",
@@ -120,10 +123,13 @@ func TestFieldMetaOptionsChoicesString(t *testing.T) {
 				"validation": null,
 				"validation_message": null
 			}
-		}
+		}}
 	`)
-	var field Field
-	require.NoError(t, json.Unmarshal(data, &field))
+	var reply = struct {
+		Data *Field `json:"data"`
+	}{}
+	require.NoError(t, json.Unmarshal(data, &reply))
+	field := reply.Data
 	require.EqualValues(t, field.Meta.ID, 1406)
 	require.Equal(t, field.Meta.Width, FieldWidthHalf)
 	require.Len(t, field.Meta.Options.Choices.Values, 2)
@@ -133,7 +139,7 @@ func TestFieldMetaOptionsChoicesString(t *testing.T) {
 
 func TestFieldMarshalCycle(t *testing.T) {
 	data := []byte(`
-		{
+		{ "data" : {
 			"collection": "contact_data",
 			"field": "phone",
 			"type": "string",
@@ -183,11 +189,13 @@ func TestFieldMarshalCycle(t *testing.T) {
 				"validation": null,
 				"validation_message": null
 			}
-		}
+		}}
 	`)
-	var field Field
-	require.NoError(t, json.Unmarshal(data, &field))
-
+	var reply = struct {
+		Data *Field `json:"data"`
+	}{}
+	require.NoError(t, json.Unmarshal(data, &reply))
+	field := reply.Data
 	write, err := json.Marshal(field)
 	require.NoError(t, err)
 


### PR DESCRIPTION
According to the doc https://directus.io/docs/api/fields#retrieve-a-field response has a data field as a parent field for the response. There was a bug during unmarshalling any request.

was expected:
```(json)
{"collection":...}
```

should be:
```(json)
{
  "data": {
    "collection": "about_us",
    "field": "id",
    "special": [],
    "options": {},
    "translations": []
  }
}

```